### PR TITLE
Add docker config for ROCm

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,24 @@
+FROM vllm-rocm:v0.6.6
+
+WORKDIR /csm
+
+RUN git clone https://github.com/davidbrowne17/csm-streaming.git /csm
+# if building from existing clone instead of above do:
+#COPY . .
+
+RUN sed -i -e 's|^vllm.*|#&|' -e 's|index-url.*|index-url=https://download.pytorch.org/whl/rocm6.2|' requirements.txt; \
+    pip install -r requirements.txt
+
+# keep an eye on https://huggingface.co/docs/bitsandbytes/non_cuda_backends
+ARG GH_BITSANDBYTES=https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_multi-backend-refactor/bitsandbytes-0.45.1.dev0-py3-none-manylinux_2_24_x86_64.whl
+
+RUN pip install --no-deps --force-reinstall "$GH_BITSANDBYTES"; \
+    pip install "triton==3.1.0"
+
+RUN apt update; apt install -y libportaudio2
+
+COPY test-docker-setup.py /tmp/
+
+EXPOSE 8000
+
+CMD ["python", "main.py"]

--- a/docker/run-csm.sh
+++ b/docker/run-csm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Syntax: run-csm.sh [/tmp/test-docker-setup.py]
+
+CSM_MODEL_PATH=$(realpath ~/.cache/huggingface/hub/models--sesame--csm-1b/snapshots/*/model.safetensors)
+CSM_CONFIG_PATH=$(realpath ~/.cache/huggingface/hub/models--sesame--csm-1b/snapshots/*/config.json)
+
+## if using pulseaudio instead of pipewire, try:
+#-v $XDG_RUNTIME_DIR/pulse/native:/tmp/pulse-native
+#-e PULSE_SERVER=unix:/tmp/pulse-native
+## or remote socket? (requires load-module module-native-protocol-tcp etc)
+#-e PULSE_SERVER=tcp:host.docker.internal
+
+docker run --rm -it -p 8000:8000 --name csm \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --device /dev/snd \
+  --group-add audio \
+  -v $XDG_RUNTIME_DIR/pipewire-0:/tmp/pipewire \
+  -e PIPEWIRE_REMOTE=unix:/tmp/pipewire \
+  -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+  -v $HOME/.cache/pip:/root/.cache/pip \
+  -v $CSM_MODEL_PATH:/csm/finetuned_model/model.safetensors \
+  -v $CSM_CONFIG_PATH:/csm/finetuned_model/config.json \
+  -v ./models:/csm/models \
+  -v ./config:/csm/config \
+  -v ./companion.db:/csm/companion.db \
+  csm-streaming "$@"
+

--- a/docker/test-docker-setup.py
+++ b/docker/test-docker-setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import sounddevice as sd
+import torch
+import runpy
+
+sndlst = sd.query_devices()
+print("== sound devices\n", sndlst)
+if len(sndlst) == 0:
+    print("did you pass --device=/dev/snd?")
+
+print("== GPUs")
+if not torch.cuda.is_available():
+    print("cuda not available!")
+    exit(1)
+
+cnt = torch.cuda.device_count()
+
+for i in range(cnt):
+    print("dev", i, "=", torch.cuda.get_device_name(i))
+
+if cnt == 0:
+    print("did you pass --device=/dev/dri?")
+    exit(1)
+else:
+    runpy.run_module("bitsandbytes", run_name="__main__")
+


### PR DESCRIPTION
My nvidia cards were lacking in VRAM so got this up and running on 7900XTX, works ok-ish, could be faster (didn't do proper testing yet but logs had these sort of numbers: 00:13<00:00, 13.00s/it, est. speed input: 70.22 toks/s, output: 7.15 toks/s, Real-time factor: 0.694x)

Building vllm and finding compatible bitsandbytes and triton versions were the main challenges, hopefully there's no need to update them in a while. vllm docs said to disable FA so did, not sure what it's status is, could be nice to get working if possible.
For some reason building vllm from their most recent master (v0.8.5+) resulted in "only" 30.8GB image, didn't check why v0.6.6 would be 100GB but I guess +-70GB is no biggie these days.